### PR TITLE
TODO 28 Se ora si cancella una nazione vengono tolti anche i colori d…

### DIFF
--- a/src/interfacciaGrafica/ControllerDeleteNation.java
+++ b/src/interfacciaGrafica/ControllerDeleteNation.java
@@ -83,6 +83,8 @@ public class ControllerDeleteNation {
             Nation num = i.next();
             if (num.getName() == nomeNazione.getValue()) {
                 ListaColori.add(num.getName());
+                num.removeAllRegions();   //tolgo nazione di appartenenza e colore della nazione alle celle che erano state
+                                          //assegnate alla nazione
                 i.remove();
             }
         }

--- a/src/interfacciaGrafica/ControllerImpostazioniGriglia.java
+++ b/src/interfacciaGrafica/ControllerImpostazioniGriglia.java
@@ -439,9 +439,8 @@ public class ControllerImpostazioniGriglia {
     //classe Nation.
     //Inoltre assegnando una certa regione ad una nazione la nazione in base alle caratteristiche
     //della regione prende un certo numero di risorse e denaro e aumenta inoltre la sua popolazione.
-    //Si va ad assegnare in maniera definitiva la cella alla nazione aggiungendo l'id della cella
-    //alla lista degli id, chiamata addRegionId, delle regioni della nazione(che rappresentano
-    //le coordinate dei territori posseduti da quella nazione).
+    //Si va ad assegnare in maniera definitiva la cella alla nazione aggiungendo l'object Regione(la cella)
+    //alla lista delle regioni possedute dalla nazione (si tratta di un array list chiamato regioni della classe Nation).
     //Inoltre, ogni volta che si clicca e quindi si colora una cella viene incrementata la variabile che tiene conto
     //del numero di celle utilizzate e se questo numero di celle utilizzate e' maggiore o uguale al prodotto
     //numero di righe per numero di colonne (indseriti dall'utente nelle apposite aree di testo)
@@ -470,10 +469,10 @@ public class ControllerImpostazioniGriglia {
                 ((Regione) event.getSource()).setNazione(nationList.get(0).getName(), nationList.get(0).getColor());
                 //AUMENTA IL NUMERO DI ABITANTI, LE RISORSE E IL DENARO DELLA NAZIONE IN BASE ALLE CARATTERISTICCHE DEL TERRITORIO ASSEGNATO
                 nationList.get(0).takeProfit(((Regione) event.getSource()).getTipo(), ((Regione) event.getSource()).getRisorse());
-                //AGGIUNGE L'ID DELLA REGIONE (DELLA CELLA) ALLA LISTA DEGLI ID DELLE CELLE ASSEGANTE ALLA NAZIONE
-                //QUINDI AGGIUNGE L'ID DELLA CELLA ALLA LISTA ADDREGIONID
-                nationList.get(0).addRegionId(((Regione) event.getSource()).getId());
-                System.out.println(nationList.get(0).getIdRegioni().get(nationList.get(0).getIdRegioni().size()-1)); //stampo l'ultimo id inserito
+                //AGGIUNGE L'OBJECT REGIONE (LA CELLA) ALLA LISTA DELLE REGIONI(LE CELLE) ASSEGNATE ALLA NAZIONE
+                //QUINDI AGGIUNGE LA CELLA ALLA LISTA REGIONI DI Nation
+                nationList.get(0).addRegion((Regione) event.getSource());
+                System.out.println(nationList.get(0).getRegioni().get(nationList.get(0).getRegioni().size()-1)); //stampo l'ultimo id inserito
                 try {
                     gridColumns = Integer.parseInt(txtColumns.getText());  		//Prende il numero di colonne inserito dall'utente nell'area di testo chiamata txtColumns
                     gridRows = Integer.parseInt(txtRows.getText());        		//Prende il numero di righe inserito dall'utente nell'area di testo chiamata txtRows

--- a/src/interfacciaGrafica/Nation.java
+++ b/src/interfacciaGrafica/Nation.java
@@ -1,5 +1,6 @@
 package interfacciaGrafica;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 //Ogni nazione e' composta dal nome, dal colore, dall'eta', dal denaro, dalle risorse e dal numero di abitanti.
 //Il colore sara' utilizzato per colorare i bottoni nella griglia.
@@ -12,10 +13,10 @@ public class Nation {
     private double risorse;                 //risorse naturali della nazione
     private int numAbitanti;                //numero di abitanti della nazione
 
-    //Lista di stringhe che rappresentano gli id delle celle assegnate e conquistate dalla nazione
-    //Quindi ogni nazione avra i suoi territorri e questa lista contiene le coordinate dei territori
+    //Lista di regioni che rappresentano le celle assegnate e conquistate dalla nazione
+    //Quindi ogni nazione avra i suoi territori e questa lista contiene i territori
     //posseduti dalla nazione
-    private  ArrayList<String> idRegioni = new ArrayList<>();
+    private  ArrayList<Regione> regioni = new ArrayList<>();
 
 
     //COSTRUTTORE CON DUE PARAMETRI
@@ -143,17 +144,25 @@ public class Nation {
     */
 
     //METODO GET ID REGIONI
-    //Restituisce l'array list di stringhe che rappresentano gli id delle regioni
-    //assegnate alla nazione
-    public ArrayList<String> getIdRegioni(){
-        return idRegioni;
+    //Restituisce l'array list di regioni assegnate alla nazione
+    public ArrayList<Regione> getRegioni(){
+        return regioni;
     }
 
-    //METODO ADD REGION ID
-    //Assegna una cella alla nazione: inserisce l'id della cella che assegnamo alla
-    //nazione sotto forma di stringa.
-    public void addRegionId(String id){
-        this.idRegioni.add(id);
+    //METODO ADD REGION
+    //Assegna una cella alla nazione: inserisce la cella(la regione) che assegnamo alla nazione
+    public void addRegion(Regione region){
+        this.regioni.add(region);
     }
 
+    //METODO REMOVE ALL REGIONS
+    //Rimuove tutte le regioni resettandole, o meglio togliendo nazione di appartenenza e colore della nazione e
+    //togliendole dall'array list regioni
+    public void removeAllRegions(){
+        for(Iterator<Regione> i = regioni.iterator(); i.hasNext();) {
+            Regione num = i.next();
+            num.resetRegion();      //toglie nazione di appartenza e colore della nazione alla regione
+            i.remove();             //toglie la regione dalla lista di quelle appartenenti alla nazione
+        }
+    }
 }

--- a/src/interfacciaGrafica/Regione.java
+++ b/src/interfacciaGrafica/Regione.java
@@ -43,6 +43,21 @@ public class Regione extends Button{
         this.valore = 0.0;
     }
 
+    //METODO RESET REGION
+    //Permette di resettare la regione: toglie la nazione di appartenza e imposta lo sfondo di default. Inoltre aggiorna
+    //il tipo della regione.
+    public void resetRegion(){
+        this.nazione = "";
+        this.refreshType();
+        //Resetta lo sfondo in base al suo tipo(sterile o fertile) e togliendo il colore della nazione
+        if(tipo.equals("fertile")){
+            this.setStyle("-fx-background-image: url('/interfacciaGrafica/IMG-Fertile.jpg')");
+        }
+        else{
+            this.setStyle("-fx-background-image: url('/interfacciaGrafica/IMG-Sterile.jpg')");
+        }
+    }
+
 
     //METODO GET RISORSE
     //Restituisce il numero di risorse naturali attuali della nazione


### PR DESCRIPTION
…alla griglia.

Quando si cancella una nazione mentre si danno le impostazioni alla griglia verranno tolti anche i pezzi di territorio che gli erano stati assegnati: questi pezzi di territorio verranno resettati togliendo nazione di appartenza e impostando il colore di default che è quello del tipo.
Inoltre quando si assegna una regione ad una nazione ora non viene più aggiunto l'id delle regione ad un array list della nazione, ma viene aggiunt la regione stessa(l'object region) in maniera da avere una facile manipolazione delle regioni assegnate alla nazione(cosa che ha permesso anche di facilitare questo commit).